### PR TITLE
Fix forum title not appearing in topic links

### DIFF
--- a/event/listener.php
+++ b/event/listener.php
@@ -320,7 +320,7 @@ class listener implements EventSubscriberInterface
 
 		$topic_row = $event['topic_row'];
 
-		$u_view_topic = $this->base->generate_topic_link($topic_row['FORUM_ID'], $topic_row['FORUM_TITLE'], $topic_row['TOPIC_ID'], $topic_row['TOPIC_TITLE']);
+		$u_view_topic = $this->base->generate_topic_link($topic_row['FORUM_ID'], $topic_row['FORUM_NAME'], $topic_row['TOPIC_ID'], $topic_row['TOPIC_TITLE']);
 		$topic_row['U_VIEW_TOPIC'] = append_sid($u_view_topic);
 		$topic_row['U_VIEW_FORUM'] = append_sid($this->base->generate_forum_link($topic_row['FORUM_ID'], $topic_row['FORUM_NAME']));
 		$topic_row['U_LAST_POST'] = append_sid($this->base->generate_lastpost_link($event['topic_row']['REPLIES'], $u_view_topic) . '#p' . $event['row']['topic_last_post_id']);


### PR DESCRIPTION
https://github.com/tas2580/seourls/commit/375ac8d796f8083c74fba20bd4891f051b5826eb Introduced a small bug due to using wrong array index name